### PR TITLE
Revert "Remove partitioning info from description"

### DIFF
--- a/control/installation.xml
+++ b/control/installation.xml
@@ -18,7 +18,9 @@
 • Includes HPC-enabled libraries
 • Disables firewall and kdump services
 • Based from minimal setup configuration
-• Installs client for the Slurm Workload Manager
+• Installs client for the Slurm Workload Manager 
+• Does not create a seperate home partition
+• Mounts a large scratch partition to /var/tmp
 </label>
   </hpc_node_description>
 </texts>

--- a/package/system-role-hpc-compute.changes
+++ b/package/system-role-hpc-compute.changes
@@ -1,10 +1,4 @@
 -------------------------------------------------------------------
-Tue Sep 25 14:40:41 UTC 2018 - dgonzalez@suse.com
-
-- Delete partitioning information from description (fate#324713)
-- 15.0.15
-
--------------------------------------------------------------------
 Wed Jun 13 09:32:07 UTC 2018 - cgoll@suse.com
 
 - Add missing aarch64 grub2 efi subvolume (bsc#1097235) 

--- a/package/system-role-hpc-compute.spec
+++ b/package/system-role-hpc-compute.spec
@@ -35,7 +35,7 @@ BuildRequires:  yast2-installation-control >= 4.0.0
 
 Url:            https://github.com/yast/system-role-hpc-compute
 AutoReqProv:    off
-Version:        15.0.15
+Version:        15.0.14
 Release:        0
 Summary:        Server HPC role definition
 License:        MIT


### PR DESCRIPTION
Reverts yast/system-role-hpc-compute#13

Because there was a misunderstood and those changes are not wanted.